### PR TITLE
Dont use a Bare except on urllib import

### DIFF
--- a/mpegdash/parser.py
+++ b/mpegdash/parser.py
@@ -3,7 +3,7 @@ from xml.dom import minidom
 # python3 support
 try:
     from urllib2 import urlopen
-except:
+except ImportError:
     from urllib.request import urlopen
 
 from mpegdash.nodes import MPEGDASH


### PR DESCRIPTION
ImportError should be reliable on both Python 2 and 3.