### PR TITLE
Use ImportError, Swap unittest import order

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 try:
-    import unittest2 as unittest
-except:
     import unittest
+except ImportError:
+    import unittest2 as unittest
 
 
 def my_module_suite():

--- a/tests/test_mpdtoxml.py
+++ b/tests/test_mpdtoxml.py
@@ -1,7 +1,7 @@
 try:
-    import unittest2 as unittest
-except:
     import unittest
+except ImportError:
+    import unittest2 as unittest
 
 from sys import version_info
 from mpegdash.parser import MPEGDASHParser

--- a/tests/test_xmltompd.py
+++ b/tests/test_xmltompd.py
@@ -1,7 +1,7 @@
 try:
-    import unittest2 as unittest
-except:
     import unittest
+except ImportError:
+    import unittest2 as unittest
 
 from mpegdash.parser import MPEGDASHParser
 


### PR DESCRIPTION
These are swapped since unittest2 is intended to be used if you're on Python 2. More people will be using Python 3 at this point so it's best to import the Python 3 module and if unable to, it will use the backport.

Most people will be using Python 3 so this will also speed things up somewhat as one less unnecessary (almost expected) try catch will be prevented.