### PR TITLE
Added missing support for endNumber inside MultipleSegmentBase

### DIFF
--- a/mpegdash/nodes.py
+++ b/mpegdash/nodes.py
@@ -226,6 +226,7 @@ class MultipleSegmentBase(SegmentBase):
 
         self.duration = None                                  # xs:unsignedInt
         self.start_number = None                              # xs:unsignedInt
+        self.end_number = None                                # xs:unsignedInt
 
         self.segment_timelines = None                         # SegmentTimelineType*
         self.bitstream_switchings = None                      # URLType*
@@ -235,6 +236,7 @@ class MultipleSegmentBase(SegmentBase):
 
         self.duration = parse_attr_value(xmlnode, 'duration', int)
         self.start_number = parse_attr_value(xmlnode, 'startNumber', int)
+        self.end_number = parse_attr_value(xmlnode, 'endNumber', int)
 
         self.segment_timelines = parse_child_nodes(xmlnode, 'SegmentTimeline', SegmentTimeline)
         self.bitstream_switchings = parse_child_nodes(xmlnode, 'BitstreamSwitching', URL)
@@ -244,6 +246,7 @@ class MultipleSegmentBase(SegmentBase):
 
         write_attr_value(xmlnode, 'duration', self.duration)
         write_attr_value(xmlnode, 'startNumber', self.start_number)
+        write_attr_value(xmlnode, 'endNumber', self.end_number)
 
         write_child_node(xmlnode, 'SegmentTimeline', self.segment_timelines)
         write_child_node(xmlnode, 'BitstreamSwitching', self.bitstream_switchings)

--- a/mpegdash/schema/dash-mpd.xsd
+++ b/mpegdash/schema/dash-mpd.xsd
@@ -293,6 +293,7 @@
         </xs:sequence>
         <xs:attribute name="duration" type="xs:unsignedInt"/>
         <xs:attribute name="startNumber" type="xs:unsignedInt"/>
+        <xs:attribute name="endNumber" type="xs:unsignedInt"/>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
   long_description_content_type='text/markdown',
   author="sangwonl",
   author_email="gamzabaw@gmail.com",
-  version="0.3.0",
+  version="0.3.1",
   license="MIT",
   zip_safe=False,
   include_package_data=True,


### PR DESCRIPTION
Hi!
Thanks for this lib! I needed to use endNumber property of MultipleSegmentBase, which was missing, so I added it.
Could you merge this into main repo and release new version to PyPi?