### PR TITLE
Workaround for TIDAL's non-compliant streaming manifest

### DIFF
--- a/mpegdash/nodes.py
+++ b/mpegdash/nodes.py
@@ -599,7 +599,15 @@ class AdaptationSet(RepresentationBase):
         RepresentationBase.parse(self, xmlnode)
 
         self.id = parse_attr_value(xmlnode, 'id', int)
-        self.group = parse_attr_value(xmlnode, 'group', int)
+        try:
+            self.group = parse_attr_value(xmlnode, 'group', int)
+        except ValueError as e:
+            # This should never happen, as the specs seem to imply that `group` is always an integer.
+            # But there is at least one case (TIDAL) that pushes strings on the manifest, and it's
+            # better not to break parsing in that case.
+            # See https://github.com/EbbLabs/python-tidal/issues/396
+            self.group = parse_attr_value(xmlnode, 'group', str)
+
         self.lang = parse_attr_value(xmlnode, 'lang', str)
         self.label = parse_attr_value(xmlnode, 'label', str)
         self.content_type = parse_attr_value(xmlnode, 'contentType', str)


### PR DESCRIPTION
As of January 2026, TIDAL started publishing non-compliant streaming manifests:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<MPD ...>
    <Period id="0">
        <AdaptationSet contentType="audio" group="main" id="0" lang="und" mimeType="audio/mp4" segmentAlignment="true">
            <!-- ... -->
        </AdaptationSet>
    </Period>
</MPD>
```

According to the MPEG-DASH specs `AdaptationSet@group` should be an integer (and that's how this library implements it).

But in this case it's a string, and that ends up breaking the manifest parsing logic.

This commit implements a fallback that tries to parse it as a string if the compliant cast fails.

Closes: https://github.com/EbbLabs/python-tidal/issues/396